### PR TITLE
attention icon added to group family sheet if family has a warning

### DIFF
--- a/resources/views/service/printables/families.blade.php
+++ b/resources/views/service/printables/families.blade.php
@@ -31,7 +31,12 @@
         </tr>
         @foreach ($registrations as $registration)
         <tr>
-          <td>{{ $registration->family->pri_carer }}</td>
+          <td>
+            @if($registration->family->getNoticeReasons())
+              <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
+            @endif
+            {{ $registration->family->pri_carer }}
+          </td>
           <td>{{ $registration->family->rvid }}</td>
           <td><i class="fa fa-ticket" aria-hidden="true"></i> {{ $registration->family->entitlement }}</td>
           <td></td>

--- a/resources/views/service/printables/families.blade.php
+++ b/resources/views/service/printables/families.blade.php
@@ -32,7 +32,7 @@
         @foreach ($registrations as $registration)
         <tr>
           <td>
-            @if($registration->family->getNoticeReasons())
+            @if(!empty($registration->family->getNoticeReasons()))
               <i class="fa fa-exclamation-circle" aria-hidden="true"></i>
             @endif
             {{ $registration->family->pri_carer }}


### PR DESCRIPTION
https://trello.com/c/zc94C2Eq/814-on-collection-sheet-the-warning-exclamation-mark-function-doesnt-seem-to-be-operating

If you could pull and check please :) because of my cached styles problem on my local copy, I can't see icons, but I tested it with the letter 'a' instead of the icon and it worked 👍 

🐧 